### PR TITLE
解决并发共用校验器链，导致校验器链丢失校验器的问题

### DIFF
--- a/design-patterns-business/src/main/java/org/landy/business/validation/Validator.java
+++ b/design-patterns-business/src/main/java/org/landy/business/validation/Validator.java
@@ -4,6 +4,8 @@ import org.landy.business.domain.detail.RequestDetail;
 import org.landy.business.domain.file.RequestFile;
 import org.landy.exception.BusinessValidationException;
 
+import java.io.Serializable;
+
 /**
  * 业务校验统一接口,增加了接口的默认方法实现，这样可以更加方便且自由选择实现接口的哪些方法。
  * @author landyl
@@ -11,7 +13,7 @@ import org.landy.exception.BusinessValidationException;
  * @version 2.0
  * @since 1.0
  */
-public interface Validator<R extends RequestDetail,F extends RequestFile> {
+public interface Validator<R extends RequestDetail,F extends RequestFile>  extends Serializable {
 
     /**
      * 需要引入责任链的时候，则采用此方法

--- a/design-patterns-business/src/main/java/org/landy/business/validation/detail/FileDetailValidatorChain.java
+++ b/design-patterns-business/src/main/java/org/landy/business/validation/detail/FileDetailValidatorChain.java
@@ -7,6 +7,7 @@ import org.landy.business.validation.Validator;
 import org.landy.business.validation.ValidatorChain;
 import org.landy.constants.Constants;
 import org.landy.exception.BusinessValidationException;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.Map;
  * @create 10:41 AM 05/09/2018
  */
 @Component
+@Scope("prototype")
 public class FileDetailValidatorChain implements ValidatorChain {
 
     Map<WorkflowEnum,List<Validator>> validatorMap = new HashMap<>();

--- a/design-patterns-business/src/main/java/org/landy/business/validation/detail/FileDetailValidatorChain.java
+++ b/design-patterns-business/src/main/java/org/landy/business/validation/detail/FileDetailValidatorChain.java
@@ -7,7 +7,6 @@ import org.landy.business.validation.Validator;
 import org.landy.business.validation.ValidatorChain;
 import org.landy.constants.Constants;
 import org.landy.exception.BusinessValidationException;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -20,7 +19,6 @@ import java.util.Map;
  * @create 10:41 AM 05/09/2018
  */
 @Component
-@Scope("prototype")
 public class FileDetailValidatorChain implements ValidatorChain {
 
     Map<WorkflowEnum,List<Validator>> validatorMap = new HashMap<>();

--- a/design-patterns-business/src/main/java/org/landy/business/validation/detail/FileDetailValidatorChain.java
+++ b/design-patterns-business/src/main/java/org/landy/business/validation/detail/FileDetailValidatorChain.java
@@ -9,6 +9,7 @@ import org.landy.constants.Constants;
 import org.landy.exception.BusinessValidationException;
 import org.springframework.stereotype.Component;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,7 +20,7 @@ import java.util.Map;
  * @create 10:41 AM 05/09/2018
  */
 @Component
-public class FileDetailValidatorChain implements ValidatorChain {
+public class FileDetailValidatorChain implements ValidatorChain, Serializable {
 
     Map<WorkflowEnum,List<Validator>> validatorMap = new HashMap<>();
     Map<WorkflowEnum,Integer> validatorIndexMap = new HashMap<>();

--- a/design-patterns-business/src/main/java/org/landy/business/validation/handler/AbstractValidatorHandler.java
+++ b/design-patterns-business/src/main/java/org/landy/business/validation/handler/AbstractValidatorHandler.java
@@ -12,7 +12,6 @@ import org.landy.utils.PackageUtil;
 import org.landy.web.utils.ApplicationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -31,9 +30,7 @@ public abstract class AbstractValidatorHandler implements ApplicationListener<Co
     private static Map<WorkflowEnum,String> validatorHandlerMap = new HashMap<>();
 
     @Autowired
-    private BeanFactory beanFactory;
-
-    FileDetailValidatorChain fileDetailValidatorChain;
+    protected FileDetailValidatorChain fileDetailValidatorChain;
 
     public AbstractValidatorHandler() {
         validatorHandlerMap.put(getWorkflowId(),accessBeanName());
@@ -94,7 +91,7 @@ public abstract class AbstractValidatorHandler implements ApplicationListener<Co
 
     private void addValidators() {
         List<Class<? extends Validator>> validators = getValidators();
-        fileDetailValidatorChain = beanFactory.getBean(FileDetailValidatorChain.class);
+
         validators.forEach((validator) -> {
             String simpleName = validator.getSimpleName();
             String beanName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);

--- a/design-patterns-business/src/main/java/org/landy/business/validation/handler/AbstractValidatorHandler.java
+++ b/design-patterns-business/src/main/java/org/landy/business/validation/handler/AbstractValidatorHandler.java
@@ -12,6 +12,7 @@ import org.landy.utils.PackageUtil;
 import org.landy.web.utils.ApplicationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -30,7 +31,9 @@ public abstract class AbstractValidatorHandler implements ApplicationListener<Co
     private static Map<WorkflowEnum,String> validatorHandlerMap = new HashMap<>();
 
     @Autowired
-    protected FileDetailValidatorChain fileDetailValidatorChain;
+    private BeanFactory beanFactory;
+
+    FileDetailValidatorChain fileDetailValidatorChain;
 
     public AbstractValidatorHandler() {
         validatorHandlerMap.put(getWorkflowId(),accessBeanName());
@@ -91,7 +94,7 @@ public abstract class AbstractValidatorHandler implements ApplicationListener<Co
 
     private void addValidators() {
         List<Class<? extends Validator>> validators = getValidators();
-
+        fileDetailValidatorChain = beanFactory.getBean(FileDetailValidatorChain.class);
         validators.forEach((validator) -> {
             String simpleName = validator.getSimpleName();
             String beanName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);

--- a/design-patterns-core/src/main/java/org/landy/utils/BeanUtil.java
+++ b/design-patterns-core/src/main/java/org/landy/utils/BeanUtil.java
@@ -64,13 +64,24 @@ public class BeanUtil {
             return null;
         }
         final FastByteArrayOutputStream byteOut = new FastByteArrayOutputStream();
-        try (ObjectOutputStream out = new ObjectOutputStream(byteOut)) {
+        ObjectOutputStream out = null;
+        //noinspection TryFinallyCanBeTryWithResources
+        try {
+            out = new ObjectOutputStream(byteOut);
             out.writeObject(obj);
             out.flush();
             final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
             return (T) in.readObject();
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            if (null != out) {
+                try {
+                    out.close();
+                } catch (Exception e) {
+                    // 静默关闭
+                }
+            }
         }
     }
 

--- a/design-patterns-core/src/main/java/org/landy/utils/BeanUtil.java
+++ b/design-patterns-core/src/main/java/org/landy/utils/BeanUtil.java
@@ -2,7 +2,12 @@ package org.landy.utils;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.springframework.util.FastByteArrayOutputStream;
 
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 
 public class BeanUtil {
@@ -43,6 +48,30 @@ public class BeanUtil {
         }
 
         return null;
+    }
+
+    /**
+     * 序列化后拷贝流的方式克隆<br>
+     * 对象必须实现Serializable接口
+     *
+     * @param <T> 对象类型
+     * @param obj 被克隆对象
+     * @return 克隆后的对象
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T cloneByStream(T obj) {
+        if (!(obj instanceof Serializable)) {
+            return null;
+        }
+        final FastByteArrayOutputStream byteOut = new FastByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(byteOut)) {
+            out.writeObject(obj);
+            out.flush();
+            final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
+            return (T) in.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.7</version>
     </dependency>
     <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
简单做了性能测试，发现部分线程校验流程缺失。对文件内容校验器链做了优化，相关类实现序列化接口克隆校验器链，入口实现多例避免并发带来的问题。测试类暂时没有提交。